### PR TITLE
removed naming scheme that makes me want to 🤮

### DIFF
--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -6,10 +6,13 @@ package frc.robot;
 
 import frc.robot.Constants.*;
 import frc.robot.subsystems.SUB_Drivetrain;
+import frc.robot.utils.LogitechController;
 import edu.wpi.first.math.MathUtil;
+import edu.wpi.first.wpilibj.Joystick;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.RunCommand;
 import edu.wpi.first.wpilibj2.command.button.CommandXboxController;
+import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 import edu.wpi.first.wpilibj2.command.button.Trigger;
 
 /**
@@ -20,11 +23,23 @@ import edu.wpi.first.wpilibj2.command.button.Trigger;
  */
 public class RobotContainer {
   // The robot's subsystems and commands are defined here...
-   public static SUB_Drivetrain drivetrain = new SUB_Drivetrain();
+  public static SUB_Drivetrain drivetrain = new SUB_Drivetrain();
 
-  // Replace with CommandPS4Controller or CommandJoystick if needed
-  private final CommandXboxController DriverC =
-      new CommandXboxController(OIConstants.kDriverControllerPort);
+  Joystick joystick = new Joystick(0);
+  LogitechController DriverC = new LogitechController(0);
+  LogitechController AssistC = new LogitechController(1);
+
+  JoystickButton d_leftBumper = DriverC.getLeftBumper();
+  JoystickButton d_rightBumper = DriverC.getRightBumper();
+
+  JoystickButton a_leftBumper = AssistC.getLeftBumper();
+  JoystickButton a_rightBumper = AssistC.getRightBumper();
+  JoystickButton a_aButton = AssistC.getAButton();
+  JoystickButton a_yButton = AssistC.getYButton(); 
+  JoystickButton a_xButton = AssistC.getXButton(); 
+  JoystickButton a_bButton = AssistC.getBButton(); 
+  JoystickButton a_startButton = AssistC.getStartButton();
+  JoystickButton a_backButton = AssistC.getBackButton();
 
   /** The container for the robot. Contains subsystems, OI devices, and commands. */
   public RobotContainer() {
@@ -38,9 +53,6 @@ public class RobotContainer {
                 -MathUtil.applyDeadband(DriverC.getRawAxis(4), OIConstants.kDriveDeadband),
                 true, true),
                 drivetrain));
-    
-    // log = DataLogManager.getLog();
-    // poseEntry = new DoubleArrayLogEntry(log, "odometry/pose");
   }
 
   /**

--- a/src/main/java/frc/robot/utils/LogitechController.java
+++ b/src/main/java/frc/robot/utils/LogitechController.java
@@ -98,11 +98,11 @@ public class LogitechController extends Joystick {
         return YButton;
     }       
           
-    public JoystickButton getLeftBumperButton(){
+    public JoystickButton getLeftBumper(){
         return leftButton;
     }   
     
-    public JoystickButton getRightBumperButton(){
+    public JoystickButton getRightBumper(){
         return rightButton;
     }  
           

--- a/src/main/java/frc/robot/utils/LogitechController.java
+++ b/src/main/java/frc/robot/utils/LogitechController.java
@@ -6,7 +6,7 @@ import edu.wpi.first.wpilibj2.command.button.JoystickButton;
 /**
  * Wrapper Class For Logitech F310 Controller
  */
-public class LogiUtils extends Joystick {
+public class LogitechController extends Joystick {
     private JoystickButton AButton;
     private JoystickButton BButton;
     private JoystickButton XButton;
@@ -68,7 +68,7 @@ public class LogiUtils extends Joystick {
      * The Constructor That Allows The User To Pass a Port Number to This Class
      * @param port,
      */
-    public LogiUtils(int port){
+    public LogitechController(int port){
         super(port);
         AButton = new JoystickButton(this, button.kABUTTON.value); 
         BButton = new JoystickButton(this, button.kBBUTTON.value);
@@ -82,43 +82,43 @@ public class LogiUtils extends Joystick {
         rightJoystickPress = new JoystickButton(this, button.kRIGHTJOYSTICKPRESS.value);
     }
     
-    public JoystickButton getAButtonPressed(){
+    public JoystickButton getAButton(){
         return AButton;
     }       
     
-    public JoystickButton getBButtonPressed(){
+    public JoystickButton getBButton(){
         return BButton;
     } 
     
-    public JoystickButton getXButtonPressed(){
+    public JoystickButton getXButton(){
         return XButton;
     }     
           
-    public JoystickButton getYButtonPressed(){
+    public JoystickButton getYButton(){
         return YButton;
     }       
           
-    public JoystickButton getLeftBumperButtonPressed(){
+    public JoystickButton getLeftBumperButton(){
         return leftButton;
     }   
     
-    public JoystickButton getRightBumperButtonPressed(){
+    public JoystickButton getRightBumperButton(){
         return rightButton;
     }  
           
-    public JoystickButton getStartButtonPressed(){
+    public JoystickButton getStartButton(){
         return startButton;
     }   
        
-    public JoystickButton getBackButtonPressed(){
+    public JoystickButton getBackButton(){
         return backButton;
     }      
      
-    public JoystickButton getLeftJoystickButtonPressed(){
+    public JoystickButton getLeftJoystickButton(){
         return leftJoystickPress;
     }       
      
-    public JoystickButton getRightJoystickButtonPressed(){
+    public JoystickButton getRightJoystickButton(){
         return rightJoystickPress;
     }  
      


### PR DESCRIPTION
In RobotContainer:
1) We should be more clear about which controllers the buttons are on in our variable names. For driver1 controllers `d_buttonName` and for driver2 controllers `a_buttonName`
2) We should be more clear about what the controllers roles are. DriverC is driver 1 and AssistC is driver2.

In LogitechController:
1) Renamed to LogitechController because LogiUtils implies it has functions that help us with using a controller rather than just outright replacing the controller.
2) If we are returning a JoystickButton instance, we shouldn't have getNButtonPressed(), just getNButton().
3) leftBumperButton/rightBumperButton changed to leftBumper/rightBumper because no one really says bumper button.
